### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet_tests.yml
+++ b/.github/workflows/dotnet_tests.yml
@@ -1,5 +1,8 @@
 name: .NET Core Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/kaua-alves-queiros/IxcNet/security/code-scanning/1](https://github.com/kaua-alves-queiros/IxcNet/security/code-scanning/1)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions for this workflow to the minimum needed. Since this workflow only checks out the repository and runs `dotnet` commands locally, it only needs read access to repository contents.

The best way to fix this without changing functionality is to add a `permissions` block at the top (root) level of `.github/workflows/dotnet_tests.yml`, right after the `name` (or before/after `on:`), setting `contents: read`. This will apply to all jobs in the workflow, including `test`, unless a specific job overrides it. No additional imports or external libraries are required.

Concretely, in `.github/workflows/dotnet_tests.yml`, add:

```yaml
permissions:
  contents: read
```

between the existing `name: .NET Core Test` line and the `on:` block. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
